### PR TITLE
Fix GitHub Actions workflow to handle files with colons in names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,7 @@ jobs:
     - name: Create bundle
       run: |
         mkdir -p bundle
+        # Copy only essential files for Docker build
         cp -r app bundle/
         cp -r ui/dist bundle/ui/
         cp -r ui/src/assets bundle/ui/
@@ -57,6 +58,16 @@ jobs:
         cp nginx.conf bundle/
         cp Makefile bundle/
         cp README.md bundle/
+        
+        # Create a tar.gz archive to avoid file path issues
+        cd bundle
+        tar -czf ../bundle.tar.gz .
+        cd ..
+        
+        # Remove the problematic directory and use the archive
+        rm -rf bundle
+        mkdir bundle
+        mv bundle.tar.gz bundle/
 
     - name: Upload bundle artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -27,6 +27,12 @@ jobs:
         name: bundle
         path: bundle
 
+    - name: Extract bundle
+      run: |
+        cd bundle
+        tar -xzf bundle.tar.gz
+        rm bundle.tar.gz
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
- Create tar.gz archive in build workflow to avoid file path issues
- Extract archive in image workflow before Docker build
- This fixes the artifact upload error caused by colons in data file names