### PR TITLE
Fix bundle extraction logic in image workflow

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Try to download bundle artifact
+      id: download-bundle
       uses: actions/download-artifact@v4
       with:
         name: bundle
@@ -30,7 +31,7 @@ jobs:
       continue-on-error: true
 
     - name: Build bundle if not available
-      if: failure()
+      if: steps.download-bundle.outcome == 'failure'
       run: |
         # Set up Python
         python -m pip install --upgrade pip
@@ -75,9 +76,13 @@ jobs:
 
     - name: Extract bundle
       run: |
-        cd bundle
-        tar -xzf bundle.tar.gz
-        rm bundle.tar.gz
+        if [ -f "bundle/bundle.tar.gz" ]; then
+          cd bundle
+          tar -xzf bundle.tar.gz
+          rm bundle.tar.gz
+        else
+          echo "Bundle already extracted or not in tar.gz format"
+        fi
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
- Add proper step ID and condition checking
- Only extract bundle if tar.gz file exists
- Fixes 'No such file or directory' error when building bundle fallback