### PR TITLE
Remove unnecessary ui/src/assets copy from Docker build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,6 @@ jobs:
         # Copy only essential files for Docker build
         cp -r app bundle/
         cp -r ui/dist bundle/ui/
-        cp -r ui/src/assets bundle/ui/
         cp pyproject.toml bundle/
         cp uv.lock bundle/
         cp Dockerfile bundle/

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -56,7 +56,6 @@ jobs:
         mkdir -p bundle
         cp -r app bundle/
         cp -r ui/dist bundle/ui/
-        cp -r ui/src/assets bundle/ui/
         cp pyproject.toml bundle/
         cp uv.lock bundle/
         cp Dockerfile bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,6 @@ COPY app/ ./app/
 # Copy built frontend from previous stage
 COPY --from=frontend-builder /app/ui/dist ./ui/dist
 
-# Copy static assets
-COPY ui/src/assets ./ui/src/assets
-
 # Expose port
 EXPOSE 8000
 


### PR DESCRIPTION
- Remove COPY ui/src/assets from Dockerfile as it's not needed
- Remove ui/src/assets from bundle creation in workflows
- Built frontend already includes all necessary assets in ui/dist
- Fixes Docker build error: '/ui/src/assets': not found