### PR TITLE
Fix package.json copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS frontend-builder
 WORKDIR /app/ui
 
 # Copy package files
-COPY ui/package*.json ./
+COPY ui/package.json ui/package-lock.json ./
 
 # Install frontend dependencies
 RUN npm install


### PR DESCRIPTION
- Use explicit COPY commands for package.json and package-lock.json
- Fixes ENOENT error: Could not read package.json
- The package*.json pattern was not working correctly