### PR TITLE
Fix npm ci to npm install in image workflow fallback

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -46,7 +46,7 @@ jobs:
         
         # Install frontend dependencies
         cd ui
-        npm ci
+        npm install
         
         # Build frontend
         npm run build


### PR DESCRIPTION
- Use npm install instead of npm ci in the fallback build step
- Consistent with Dockerfile fix
- Should resolve the package.json not found error in GitHub Actions