### PR TITLE
Fix bundle creation to include full ui/ directory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         mkdir -p bundle
         # Copy only essential files for Docker build
         cp -r app bundle/
-        cp -r ui/dist bundle/ui/
+        cp -r ui bundle/
         cp pyproject.toml bundle/
         cp uv.lock bundle/
         cp Dockerfile bundle/

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -64,7 +64,7 @@ jobs:
         # Create bundle
         mkdir -p bundle
         cp -r app bundle/
-        cp -r ui/dist bundle/ui/
+        cp -r ui bundle/
         cp pyproject.toml bundle/
         cp uv.lock bundle/
         cp Dockerfile bundle/


### PR DESCRIPTION
- Copy entire ui/ directory instead of just ui/dist
- Ensures package.json and package-lock.json are available for Docker build
- Fixes Docker build context issue with missing ui/package.json