### PR TITLE
Add debugging and disable Docker cache to fix build loops

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -92,6 +92,15 @@ jobs:
           echo "Bundle already extracted or not in tar.gz format"
         fi
 
+    - name: Debug bundle contents
+      run: |
+        echo "Bundle directory contents:"
+        ls -la bundle/
+        echo "UI directory contents:"
+        ls -la bundle/ui/ || echo "UI directory not found"
+        echo "Package.json exists:"
+        ls -la bundle/ui/package.json || echo "package.json not found"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -122,5 +131,3 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -3,7 +3,6 @@ name: Build Docker Image
 on:
   push:
     branches: [ main ]
-    tags: [ 'v*' ]
   workflow_dispatch:
   workflow_call:
 
@@ -30,10 +29,20 @@ jobs:
         path: bundle
       continue-on-error: true
 
-    - name: Check if bundle exists
+    - name: Extract bundle
+      run: |
+        if [ -f "bundle/bundle.tar.gz" ]; then
+          cd bundle
+          tar -xzf bundle.tar.gz
+          rm bundle.tar.gz
+        else
+          echo "Bundle already extracted or not in tar.gz format"
+        fi
+
+    - name: Check if bundle exists after extraction
       id: check-bundle
       run: |
-        if [ -d "bundle" ] && [ -f "bundle/bundle.tar.gz" ]; then
+        if [ -d "bundle" ] && [ -f "bundle/ui/package.json" ]; then
           echo "bundle-exists=true" >> $GITHUB_OUTPUT
         else
           echo "bundle-exists=false" >> $GITHUB_OUTPUT
@@ -81,16 +90,6 @@ jobs:
         rm -rf bundle
         mkdir bundle
         mv bundle.tar.gz bundle/
-
-    - name: Extract bundle
-      run: |
-        if [ -f "bundle/bundle.tar.gz" ]; then
-          cd bundle
-          tar -xzf bundle.tar.gz
-          rm bundle.tar.gz
-        else
-          echo "Bundle already extracted or not in tar.gz format"
-        fi
 
     - name: Debug bundle contents
       run: |


### PR DESCRIPTION
- Add debug step to show bundle contents
- Disable Docker cache temporarily to identify issue
- This should help identify why the build is running in cycles