### PR TITLE
Fix Docker build loop issues

### DIFF
--- a/.github/workflows/build-and-image.yaml
+++ b/.github/workflows/build-and-image.yaml
@@ -90,7 +90,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: ./bundle
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 
 # Install Python dependencies
-RUN uv sync --frozen --no-cache
+RUN uv sync --frozen
 
 # Copy application code
 COPY app/ ./app/


### PR DESCRIPTION
- Build for single platform (linux/amd64) to eliminate multi-platform conflicts
- Remove --no-cache flag from uv sync to enable proper caching
- This should resolve the infinite loop behavior in Docker build