### PR TITLE
ci: bump Node.js 20 (EOL) -> 22 LTS in CI workflows

### DIFF
--- a/.github/workflows/build-and-image.yaml
+++ b/.github/workflows/build-and-image.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
 


### PR DESCRIPTION
## Summary

Bumps the CI/build Node.js runtime off the end-of-life Node 20, addressing an outdated-component finding (CWE-1104) from a recent security audit of this repo.

- `.github/workflows/ci.yaml`: `node-version: '20'` → `'22'`
- `.github/workflows/build-and-image.yaml`: `node-version: '20'` → `'22'`

Node.js 20 ("Iron") reached end-of-life on **2026-03-24**, so it no longer receives security or bug fixes. The frontend build + npm dependency install run in CI on that runtime. **Node 22** is the current Active LTS and satisfies the toolchain's engine requirements (e.g. Vite 7 needs `>=20.19 || >=22.12`).

## Scope / verification

- CI runtime only — no application code, no dependency changes, and `ui/package-lock.json` is untouched.
- Only the two `node-version` values change; `setup-node` caching config is unchanged.
- The frontend build is validated by CI under Node 22.
